### PR TITLE
parse out OpenIndiana variant of Solaris

### DIFF
--- a/lib/Devel/Platform/Info/Solaris.pm
+++ b/lib/Devel/Platform/Info/Solaris.pm
@@ -42,7 +42,7 @@ sub get_info {
     $self->{info}{is32bit}  = $self->{cmds}{_isainfo} !~ /64-bit/s ? 1 : 0;
     $self->{info}{is64bit}  = $self->{cmds}{_isainfo} =~ /64-bit/s ? 1 : 0;
 
-    ($self->{info}{osname}) = $self->{cmds}{_release} =~ /((?:Open)?Solaris|SunOS)/is;
+    ($self->{info}{osname}) = $self->{cmds}{_release} =~ /((?:Open)?Solaris|SunOS|OpenIndiana)/is;
     $self->{info}{oslabel}  = $self->{info}{osname};
     $self->{info}{osvers}   = $self->{info}{kvers};
 


### PR DESCRIPTION
This patch changes Devel::Platform::Info::Solaris to recognize OpenIndiana, an open source fork of Solars.
